### PR TITLE
Remove Node 20 from CI and default ncc build to Node 24

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x]
 
     steps:
     - uses: actions/checkout@v6
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         FILES_EXTENSION: [.pm, .bck, .pm.bck, .pm|.bck ]
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x]
 
     env:
       CONTROLS_FILE: controls_tests.txt


### PR DESCRIPTION
 ## Summary

  - remove Node 20 from the CI test matrices
  - keep CI coverage for Node 22 and Node 24
  - run the automatic ncc/dist build with Node 24 by default

  ## Reason

  `@vercel/ncc` 0.43+ no longer supports Node 20. The action runtime is already configured for Node 24 in `action.yml`, so the workflow should stop testing/building with Node 20 before updating ncc to 0.44.x.

  ## Verification

  - `npm test`
  - `docker run ... node:24 npm test`
  - `docker run ... node:24 npm run build --if-present`